### PR TITLE
Removed item class from Paginator next button

### DIFF
--- a/src/components/shared/misc/Paginator.vue
+++ b/src/components/shared/misc/Paginator.vue
@@ -9,7 +9,7 @@
         <a :class="startClass" @click="current = 1">First Page</a>
         <a :class="startClass" @click="current -= 1">Prev</a>
         <a class="item">Page {{current}} of {{pagination.total_pages}}</a>
-        <a :class="endClass" class="item" @click="current += 1">Next</a>
+        <a :class="endClass" @click="current += 1">Next</a>
         <a :class="endClass" @click="current = pagination.total_pages">Last Page</a>
     </div>
 </template>


### PR DESCRIPTION
I've removed the **_item_** class on the **_next button_** because it's already getting the class from the **_endClass_** method. No noticeable changes but would just like to confirm that this won't break anything.