### PR TITLE
Profile component changes

### DIFF
--- a/src/components/shared/misc/ImageUploader.vue
+++ b/src/components/shared/misc/ImageUploader.vue
@@ -283,9 +283,7 @@
                         }))
 
                         tester.addEventListener('error', (() => {
-                            if (this.defaultSrc === null) {
-                                this.src = ''
-                            } else this.src = this.defaultSrc
+                            this.src = this.defaultSrc || ''
                         }))
                     }
 

--- a/src/components/shared/misc/ImageUploader.vue
+++ b/src/components/shared/misc/ImageUploader.vue
@@ -195,37 +195,37 @@
             },
 
             uploadFile() {
-                if (this.image === null || (this.getDefaultSrc.length && this.image.indexOf(this.getDefaultSrc) > -1)) {
+                if (this.image === null || this.image.indexOf(this.defaultSrc) > -1) {
                     this.$emit('image-reset')
                     this.showModal = !this.showModal
-                } else {
-                    this.loading = true
-
-                    this.croppie.result(
-                        { type: 'blob',
-                            size: 'viewport',
-                            name: 'profile',
-                        }).then((response) => {
-                            this.image = response
-                            // Axios request
-                            if (this.url) {
-                                const formData = new FormData()
-                                formData.append('file', this.image)
-                                this.$http.post(this.url, formData, {
-                                    headers: this.requestHeaders,
-                                }).then((res) => {
-                                    this.$emit('image-set', res.data.data)
-                                    this.loading = false
-                                    this.showModal = !this.showModal
-                                })
-                            } else {
-                                this.profileSet(window.URL.createObjectURL(response))
-                                this.$emit('image-set', window.URL.createObjectURL(response))
-                                this.showModal = !this.showModal
-                                this.loading = false
-                            }
-                        })
+                    return
                 }
+                this.loading = true
+
+                this.croppie.result(
+                    { type: 'blob',
+                        size: 'viewport',
+                        name: 'profile',
+                    }).then((response) => {
+                        this.image = response
+                        // Axios request
+                        if (this.url) {
+                            const formData = new FormData()
+                            formData.append('file', this.image)
+                            this.$http.post(this.url, formData, {
+                                headers: this.requestHeaders,
+                            }).then((res) => {
+                                this.$emit('image-set', res.data.data)
+                                this.loading = false
+                                this.showModal = !this.showModal
+                            })
+                        } else {
+                            this.profileSet(window.URL.createObjectURL(response))
+                            this.$emit('image-set', window.URL.createObjectURL(response))
+                            this.showModal = !this.showModal
+                            this.loading = false
+                        }
+                    })
             },
 
             setUpCroppie() {
@@ -302,12 +302,7 @@
             },
 
             containsDefaultSrc() {
-                if (this.getDefaultSrc.length) return this.src.indexOf(this.getDefaultSrc) > -1
-                return false
-            },
-
-            getDefaultSrc() {
-                return this.defaultSrc || ''
+                return this.src.indexOf(this.defaultSrc) > -1
             },
         },
     }

--- a/src/components/shared/misc/ImageUploader.vue
+++ b/src/components/shared/misc/ImageUploader.vue
@@ -3,7 +3,7 @@
         <slot>
             <div class="ui very padded center aligned container">
                 <slot name="profile-current">
-                    <img class="ui small centered circular image" v-if="imgSrc" :src="getSrc">
+                    <img class="ui small centered circular image" v-if="imgSrc" :src="src">
                 </slot>
                 <div v-if="!readOnly">
                     <semantic-divider />
@@ -24,7 +24,7 @@
                             <input ref="select" name="image-upload" type="file" accept="image/*" id="upload-image" v-on:change="setUpFileUploader" style="display: none">
                         </div>
 
-                        <button v-if="(image !== null && !containsDefaultSrc && getSrc !== '') || imageAdded" class="ui button" @click="resetCroppie">
+                        <button v-if="(image !== null && !containsDefaultSrc && src !== '') || imageAdded" class="ui button" @click="resetCroppie">
                             Remove Current
                         </button>
 
@@ -193,7 +193,7 @@
             },
 
             profileSet(image) {
-                this.getSrc = image
+                this.src = image
             },
 
             uploadFile() {
@@ -273,16 +273,7 @@
 
         computed: {
             cors() {
-                return this.getSrc.length ? `${this.getSrc}?v=cors` : ''
-            },
-
-            getSrc: {
-                get() {
-                    return this.src
-                },
-                set(val) {
-                    this.src = val
-                },
+                return this.src.length ? `${this.src}?v=cors` : ''
             },
 
             imgSrc() {
@@ -291,11 +282,11 @@
 
                     if (!this.eventListenersAdded) {
                         tester.addEventListener('load', (() => {
-                            this.getSrc = this.imgUrl
+                            this.src = this.imgUrl
                         }))
 
                         tester.addEventListener('error', (() => {
-                            this.getSrc = this.defaultSrc || ''
+                            this.src = this.defaultSrc || ''
                         }))
                     }
 
@@ -312,8 +303,8 @@
             },
 
             containsDefaultSrc() {
-                if (this.getSrc === null) return false
-                return this.getSrc.indexOf(this.defaultSrc) > -1
+                if (this.src === null) return false
+                return this.src.indexOf(this.defaultSrc) > -1
             },
         },
     }

--- a/src/components/shared/misc/ImageUploader.vue
+++ b/src/components/shared/misc/ImageUploader.vue
@@ -92,7 +92,7 @@
             * Fallback default picture / placeholder
             */
             defaultSrc: {
-                type: [Boolean, String],
+                type: String,
                 default: '/img/defaultAvatar.png',
             },
 
@@ -195,7 +195,7 @@
             },
 
             uploadFile() {
-                if (this.image === null || this.image.indexOf(this.defaultSrc) > -1) {
+                if (this.image === null || this.image.indexOf(this.getDefaultSrc) > -1) {
                     this.$emit('image-reset')
                     this.showModal = !this.showModal
                 } else {
@@ -254,14 +254,16 @@
 
             resetCroppie() {
                 this.croppie.destroy()
-                this.setUpCroppie()
-                this.image = null
                 this.$nextTick(() => {
-                    this.croppie.bind({
-                        url: '',
+                    this.setUpCroppie()
+                    this.$nextTick(() => {
+                        this.image = null
+                        this.croppie.bind({
+                            url: '',
+                        })
                     })
+                    $(this.$refs.select).val('')
                 })
-                $('#upload-image').val('')
             },
         },
 
@@ -281,7 +283,7 @@
                         }))
 
                         tester.addEventListener('error', (() => {
-                            if (!this.defaultSrc) {
+                            if (this.defaultSrc === null) {
                                 this.src = ''
                             } else this.src = this.defaultSrc
                         }))
@@ -300,8 +302,12 @@
             },
 
             containsDefaultSrc() {
-                if (this.src.indexOf(this.defaultSrc) > -1) return true
+                if (this.getDefaultSrc.length) return this.src.indexOf(this.getDefaultSrc) > -1
                 return false
+            },
+
+            getDefaultSrc() {
+                return this.defaultSrc || ''
             },
         },
     }

--- a/src/components/shared/misc/ImageUploader.vue
+++ b/src/components/shared/misc/ImageUploader.vue
@@ -269,8 +269,7 @@
 
         computed: {
             cors() {
-                if (!this.src.length) return ''
-                return `${this.src}?v=cors`
+                return this.src.length ? `${this.src}?v=cors` : ''
             },
 
             imgSrc() {

--- a/src/components/shared/misc/ImageUploader.vue
+++ b/src/components/shared/misc/ImageUploader.vue
@@ -282,7 +282,7 @@
 
                         tester.addEventListener('error', (() => {
                             if (!this.defaultSrc) {
-                                this.src = null
+                                this.src = ''
                             } else this.src = this.defaultSrc
                         }))
                     }
@@ -300,9 +300,8 @@
             },
 
             containsDefaultSrc() {
-                if (this.src.length) {
-                    if (this.src.indexOf(this.defaultSrc) > -1) return true
-                } return false
+                if (this.src.indexOf(this.defaultSrc) > -1) return true
+                return false
             },
         },
     }

--- a/src/components/shared/misc/ImageUploader.vue
+++ b/src/components/shared/misc/ImageUploader.vue
@@ -157,14 +157,14 @@
                     onVisible: () => {
                         if (this.imgUrl === '') {
                             this.image = null
-                        } else {
-                            this.image = this.cors
-                            this.$nextTick(() => {
-                                this.croppie.bind({
-                                    url: this.image,
-                                })
-                            })
+                            return
                         }
+                        this.image = this.cors
+                        this.$nextTick(() => {
+                            this.croppie.bind({
+                                url: this.image,
+                            })
+                        })
                     },
                 },
             }

--- a/src/components/shared/misc/ImageUploader.vue
+++ b/src/components/shared/misc/ImageUploader.vue
@@ -195,7 +195,7 @@
             },
 
             uploadFile() {
-                if (this.image === null || this.image.indexOf(this.getDefaultSrc) > -1) {
+                if (this.image === null || (this.getDefaultSrc.length && this.image.indexOf(this.getDefaultSrc) > -1)) {
                     this.$emit('image-reset')
                     this.showModal = !this.showModal
                 } else {

--- a/src/components/shared/misc/ProfileHeader.vue
+++ b/src/components/shared/misc/ProfileHeader.vue
@@ -1,6 +1,5 @@
 <template>
     <div class="ui stackable grid">
-
         <div class="three wide column">
 
             <croud-image-uploader ref="uploader"
@@ -9,17 +8,21 @@
                                   :url="url"
                                   :requstHeaders="requestHeaders"
                                   :readOnly="readOnly"
-                                  @image-set="profilePicSet">
+                                  :defaultSrc="false"
+                                  @image-set="profilePicSet"
+                                  @image-reset="user.avatar = ''">
 
                 <div slot="profile-current">
 
                     <croud-avatar :user="getUser" size="small"/>
 
                 </div>
-                <slot name="action">
-                    <button class="ui blue fluid button" slot="action" @click="$refs.uploader.showModal = !$refs.uploader.showModal">Set Image</button>
-                </slot>
 
+                <div slot="action">
+                    <slot name="custom-action">
+                        <button class="ui blue fluid button" slot="action" @click="$refs.uploader.showModal = !$refs.uploader.showModal">Change</button>
+                    </slot>
+                </div>
             </croud-image-uploader>
         </div>
 

--- a/src/components/shared/misc/ProfileHeader.vue
+++ b/src/components/shared/misc/ProfileHeader.vue
@@ -8,7 +8,7 @@
                                   :url="url"
                                   :requstHeaders="requestHeaders"
                                   :readOnly="readOnly"
-                                  :defaultSrc="false"
+                                  :defaultSrc="null"
                                   @image-set="profilePicSet"
                                   @image-reset="user.avatar = ''">
 

--- a/test/unit/misc/__snapshots__/ImageUploader.spec.js.snap
+++ b/test/unit/misc/__snapshots__/ImageUploader.spec.js.snap
@@ -6,7 +6,6 @@ exports[`Image Uploader should match the snapshot 1`] = `
     class="ui very padded center aligned container"
   >
     <img
-      src="/img/defaultAvatar.png"
       class="ui small centered circular image"
     />
     <div>

--- a/test/unit/misc/__snapshots__/ProfileHeader.spec.js.snap
+++ b/test/unit/misc/__snapshots__/ProfileHeader.spec.js.snap
@@ -150,11 +150,13 @@ exports[`Profile header should match the snapshot 1`] = `
           <div
             class="ui divider"
           />
-          <button
-            class="ui blue fluid button"
-          >
-            Set Image
-          </button>
+          <div>
+            <button
+              class="ui blue fluid button"
+            >
+              Change
+            </button>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Adds a button in the image uploader modal for removing a set avatar, also emits an image-reset event on saving, also in the image uploader a change so the default src can be set to false, if so no default will be applied.

Slight mods in the profile header component adding a listener to the image-reset event, which clears the avatar param in the user object, also a change to the button text and a fix to the syntax for the custom slot for the action button