### PR TITLE
Dashboard changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "croud-date-parser": "git+https://github.com/CroudSupport/croud-date-parser.git",
     "pikaday": "^1.6.1",
     "tool": "^6.0.0",
-    "vuetable-2": "^1.6.5"
+    "vuetable-2": "^1.7.0"
   },
   "devDependencies": {
     "@mapbox/stylelint-processor-arbitrary-tags": "^0.1.1",

--- a/src/components/shared/Datatable.vue
+++ b/src/components/shared/Datatable.vue
@@ -44,6 +44,9 @@
                 createElement('div', { class: ['ui', 'segment', 'grid', 'basic'] }, [
                     createElement('vuetable-pagination-info', {
                         ref: 'paginationInfo',
+                        props: {
+                            noDataTemplate: '',
+                        },
                     }),
                     createElement(this.paginatorComponent, {
                         ref: 'pagination',
@@ -120,6 +123,17 @@
                 type: Function,
                 default(sortOrder) {
                     return sortOrder.map(sort => (`${sort.sortField},${sort.direction}`)).join('|')
+                },
+            },
+
+            /**
+             * noDataTemplate - You can use this to define what is displayed when there is no data to populate in the table.
+             * You can pass html or text
+             */
+            noDataTemplate: {
+                type: String,
+                default() {
+                    return '<div class="ui center aligned basic segment"><i class="big circular yellow list icon"></i></br>No Results</div>'
                 },
             },
         },

--- a/src/components/shared/Datatable.vue
+++ b/src/components/shared/Datatable.vue
@@ -125,17 +125,6 @@
                     return sortOrder.map(sort => (`${sort.sortField},${sort.direction}`)).join('|')
                 },
             },
-
-            /**
-             * noDataTemplate - You can use this to define what is displayed when there is no data to populate in the table.
-             * You can pass html or text
-             */
-            noDataTemplate: {
-                type: String,
-                default() {
-                    return '<div class="ui center aligned basic segment"><i class="big circular yellow list icon"></i></br>No Results</div>'
-                },
-            },
         },
 
         methods: {
@@ -170,6 +159,7 @@
                         page: 'page',
                         perPage: 'per_page',
                     },
+                    noDataTemplate: '<div class="ui center aligned basic segment"><i class="big circular yellow list icon"></i></br>No Results</div>',
                     css: {
                         tableClass: 'ui table',
                         dropdownClass: 'ui dropdown',

--- a/src/components/shared/croud-datatable.md
+++ b/src/components/shared/croud-datatable.md
@@ -109,16 +109,10 @@ If there is no data or results to display, the no results message will display a
 
 If you wish to customize this message, you can set a **noDataTemplate** in the vuetable-config containing a string or html to parse, as below
 
-```js static
-
-    noDataTemplate: '<div class="ui center aligned basic segment"><strong>No Data to show you!</strong>',
-
-```
-
     <croud-datatable
         :vuetable-config="{
             'pagination-path': '',
             fields: [{ name: 'name', sortField: 'name' }, 'email', { name:'birthdate', title: 'DOB' }],
-            noDataTemplate: this.customDatagridMarkup,
+            noDataTemplate: '<div class=`ui center aligned basic segment`><strong>No Data to show you!</strong></div>',
         }"
     />

--- a/src/components/shared/croud-datatable.md
+++ b/src/components/shared/croud-datatable.md
@@ -96,8 +96,6 @@ You can pass through scoped slots to generate more complex columns
         </template>
     </croud-datatable>
 
-    Please ignore the **pagination-path** setting, **transform** prop and the **getSortParam** prop in the following examples. This component sets the default to work with data from **Core**
-
 ### No Results - Customising the default no data message
 If there is no data or results to display, the no results message will display as below
 

--- a/src/components/shared/croud-datatable.md
+++ b/src/components/shared/croud-datatable.md
@@ -95,3 +95,32 @@ You can pass through scoped slots to generate more complex columns
             </button>
         </template>
     </croud-datatable>
+
+    Please ignore the **pagination-path** setting, **transform** prop and the **getSortParam** prop in the following examples. This component sets the default to work with data from **Core**
+
+### No Results - Customising the default no data message
+If there is no data or results to display, the no results message will display as below
+
+    <croud-datatable
+        :vuetable-config="{
+            'pagination-path': '',
+            fields: [{ name: 'name', sortField: 'name' }, 'email', { name:'birthdate', title: 'DOB' }],
+        }"
+    />
+
+
+If you wish to customize this message, you can set a **noDataTemplate** in the vuetable-config containing a string or html to parse, as below
+
+```js static
+
+    noDataTemplate: '<div class="ui center aligned basic segment"><strong>No Data to show you!</strong>',
+
+```
+
+    <croud-datatable
+        :vuetable-config="{
+            'pagination-path': '',
+            fields: [{ name: 'name', sortField: 'name' }, 'email', { name:'birthdate', title: 'DOB' }],
+            noDataTemplate: this.customDatagridMarkup,
+        }"
+    />

--- a/src/components/shared/forms/DateRange.vue
+++ b/src/components/shared/forms/DateRange.vue
@@ -131,7 +131,7 @@
                     onSelect: (val) => {
                         this.localEnd = moment(val)
                         this.picker.destroy()
-                        this.$nextTick(this.buildStart)
+                        $(this.$refs.input).popup('hide')
                     },
                 })
             },
@@ -169,16 +169,12 @@
                       }
                       this.$nextTick(this.buildStart)
                   },
+                  onHidden: () => {
+                      this.$emit('update:start', this.localStart)
+                      this.$emit('update:end', this.localEnd)
+                  },
               })
         },
-
-        watch: {
-            localEnd() {
-                this.$emit('update:start', this.localStart)
-                this.$emit('update:end', this.localEnd)
-            },
-        },
-
     }
 </script>
 

--- a/src/mixins/styleguidist.js
+++ b/src/mixins/styleguidist.js
@@ -153,6 +153,7 @@ export default {
                     { name: 'Amazon Prime' },
                 ],
             },
+            customDatagridMarkup: '<div class="ui center aligned basic segment"><strong>No Data to show you!</strong>',
         }
     },
 

--- a/src/mixins/styleguidist.js
+++ b/src/mixins/styleguidist.js
@@ -153,7 +153,6 @@ export default {
                     { name: 'Amazon Prime' },
                 ],
             },
-            customDatagridMarkup: '<div class="ui center aligned basic segment"><strong>No Data to show you!</strong>',
         }
     },
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14199,9 +14199,9 @@ vue@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.4.2.tgz#a9855261f191c978cc0dc1150531b8d08149b58c"
 
-vuetable-2@^1.6.5:
-  version "1.6.5"
-  resolved "https://registry.yarnpkg.com/vuetable-2/-/vuetable-2-1.6.5.tgz#919d2d0f7a672733c384b0036c4c24c2f92bd68c"
+vuetable-2@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/vuetable-2/-/vuetable-2-1.7.0.tgz#7bd4268aa937b98884ab3250d7cbf20c4b3d539c"
   dependencies:
     axios "^0.15.3"
 


### PR DESCRIPTION
This PR adds some usability refinements to the dateRange component, it closes the popup menu when the enddate is chosen, it also allows for just the start date to be changed so updates when hiding the popup rather than when the enddate is chosen.

It also bumps the vuetable version which now uses v-html on the no data message, so i have passed in a more user friendly (pretty) no data message.. also it passes a blank template to the pagination summary for when there is no data rather than displaying the no relevant data message.