### PR TITLE
Status label

### DIFF
--- a/src/components/shared/misc/Status.vue
+++ b/src/components/shared/misc/Status.vue
@@ -1,0 +1,80 @@
+<template>
+    <div :class="classes">
+        {{ status }}
+    </div>
+</template>
+
+<script>
+    /**
+     * Status label for tasks and jobs
+     *
+     * @example ./croud-status.md
+     */
+    export default {
+        name: 'croud-status',
+
+        props: {
+            /**
+             * Job or task object
+             */
+            context: {
+                type: Object,
+                required: true,
+            },
+        },
+
+        computed: {
+            classes() {
+                const classNames = ['ui', 'label', 'circular', 'basic', 'status-label', 'fluid', 'tiny']
+
+                if (this.context.status === 'deleted' || this.context.deleted_at) {
+                    classNames.push('red')
+                } else {
+                    switch (this.context.status) {
+                    case 'new':
+                        classNames.push('grey')
+                        break
+                    case 'open':
+                        classNames.push('grey')
+                        break
+                    case 'in_progress':
+                        classNames.push(this.context.qa ? 'blue' : 'yellow')
+                        break
+                    case 'approval':
+                        classNames.push('blue')
+                        break
+                    case 'complete':
+                        classNames.push('green')
+                        break
+                    default:
+                        classNames.push('grey')
+                        break
+                    }
+                }
+
+                return classNames
+            },
+
+            status() {
+                let status = this.context.status
+
+                if (this.context.deleted_at) {
+                    status = 'Cancelled'
+                }
+
+                switch (status) {
+                case 'in_progress':
+                    status = this.context.qa ? 'qa_task' : status
+                    break
+                case 'deleted':
+                    status = 'Cancelled'
+                    break
+                default:
+                    break
+                }
+
+                return status.replace('_', ' ').toUpperCase()
+            },
+        },
+    }
+</script>

--- a/src/components/shared/misc/croud-status.md
+++ b/src/components/shared/misc/croud-status.md
@@ -1,0 +1,27 @@
+### Basic usage
+Simply add the **croud-status** in the markup and pass through the context in a prop
+
+    <table class="ui very basic fixed table">
+        <tr>
+            <td>
+                <croud-status :context="{status: 'new'}" />
+            </td>
+            <td>
+                <croud-status :context="{status: 'open'}" />
+            </td>
+            <td>
+                <croud-status :context="{status: 'in_progress'}" />
+            </td>
+            <td>
+                <croud-status :context="{status: 'approval'}" />
+            </td>
+            <td>
+                <croud-status :context="{status: 'complete'}" />
+            </td>
+            <td>
+                <croud-status :context="{status: 'deleted'}" />
+            </td>
+        </tr>
+    </table>
+
+

--- a/test/unit/misc/Status.spec.js
+++ b/test/unit/misc/Status.spec.js
@@ -1,0 +1,41 @@
+import Vue from 'vue'
+import moment from 'moment'
+import Status from '../../../src/components/shared/misc/Status'
+
+const Constructor = Vue.extend(Status)
+
+const context = {
+    status: 'in_progress',
+    qa: false,
+    deleted_at: null,
+}
+
+const vm = new Constructor({
+    propsData: {
+        context,
+    },
+}).$mount()
+
+describe('Status', () => {
+    it('should match the snapshot', () => {
+        expect(vm.$el).toMatchSnapshot()
+    })
+
+    it('should respect the qa flag', (done) => {
+        context.qa = true
+        vm.$nextTick(() => {
+            expect(vm.classes).toContain('blue')
+            expect(vm.status).toBe('QA TASK')
+            done()
+        })
+    })
+
+    it('should respect a deleted_at date', (done) => {
+        context.deleted_at = moment()
+        vm.$nextTick(() => {
+            expect(vm.classes).toContain('red')
+            expect(vm.status).toBe('CANCELLED')
+            done()
+        })
+    })
+})

--- a/test/unit/misc/__snapshots__/Status.spec.js.snap
+++ b/test/unit/misc/__snapshots__/Status.spec.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Status should match the snapshot 1`] = `
+<div
+  class="ui label circular basic status-label fluid tiny yellow"
+>
+  IN PROGRESS
+</div>
+`;


### PR DESCRIPTION
Status label moved to reusable component, no style changes.
Complete with tech docs, snapshot and edge case tests.
Compatible with both Vue 1 and 2 and a single place to put all the upcoming status logic changes.