### PR TITLE
Use activated life cycle hook for keep-alive components

### DIFF
--- a/src/components/shared/forms/DateRange.vue
+++ b/src/components/shared/forms/DateRange.vue
@@ -153,7 +153,9 @@
 
         mounted() {
             this.buildStart()
+        },
 
+        activated() {
             $(this.$refs.input)
               .popup({
                   inline: true,


### PR DESCRIPTION
Move jQuery initialisation to activated lifecycle hook.