### PR TITLE
New lazy load HOC

### DIFF
--- a/src/components/shared/hoc/LazyLoad.vue
+++ b/src/components/shared/hoc/LazyLoad.vue
@@ -7,7 +7,7 @@
 
 <script>
     /**
-     * Lazy load any child content when this hoc comes into view
+     * Lazy load any child content when this higher order component comes into view
      *
      * @example ./lazy-load.md
      */
@@ -15,6 +15,10 @@
         name: 'lazy-load',
 
         props: {
+            /**
+             * Intersection Observer options
+             * @see https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API
+             */
             options: {
                 type: Object,
                 default() {

--- a/src/components/shared/hoc/LazyLoad.vue
+++ b/src/components/shared/hoc/LazyLoad.vue
@@ -1,0 +1,51 @@
+<template>
+  <div v-if="outOfView" class="placeholder">&nbsp;</div>
+  <div v-else>
+    <slot></slot>
+  </div>
+</template>
+
+<script>
+    /**
+     * Lazy load any child content when this hoc comes into view
+     *
+     * @example ./lazy-load.md
+     */
+    export default {
+        name: 'lazy-load',
+
+        props: {
+            options: {
+                type: Object,
+                default() {
+                    return {}
+                },
+            },
+        },
+
+        data() {
+            return {
+                outOfView: true,
+            }
+        },
+
+        mounted() {
+            const observer = new IntersectionObserver((entries) => {
+                entries.forEach((entry) => {
+                    if (entry.intersectionRatio > 0) {
+                        this.outOfView = false
+                        observer.disconnect()
+                    }
+                })
+            }, this.options)
+
+            observer.observe(this.$el)
+        },
+    }
+</script>
+
+<style scoped>
+    .placeholder {
+        min-height: 10px;
+    }
+</style>

--- a/src/components/shared/hoc/lazy-load.md
+++ b/src/components/shared/hoc/lazy-load.md
@@ -1,0 +1,22 @@
+### Basic usage
+This Higher Order Component can be used to wrap content that should only be loaded when in the viewport. The example below will only load this large image when in view. (Check your network tab)
+
+    <lazy-load>
+        <img src="http://lorempicsum.com/simpsons/1000/1000/9" />
+    </lazy-load>
+
+### Lazy Load Components
+As well as lazy loading content, this also works with Vue components, so you can offset expensive `mounted` functions until the component is actually needed in the viewport.
+
+    <lazy-load>
+        <croud-datatable
+        :vuetable-config="{
+            'pagination-path': '',
+            fields: [{ name: 'name', sortField: 'name' }, 'email', { name:'birthdate', title: 'DOB' }],
+            'api-url': 'http://vuetable.ratiw.net/api/users',
+            'query-params': { sort: 'sort' }
+        }"
+        :transform="data => data"
+        :getSortParam="(sortOrder) => sortOrder.map(sort => (`${sort.sortField}|${sort.direction}`)).join(',')"
+    />
+    </lazy-load>

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -86,6 +86,10 @@ module.exports = {
                 },
             ],
         },
+        {
+            name: 'HOC',
+            components: 'src/components/shared/hoc/**/*.vue',
+        },
     ],
     styleguideComponents: {
         Logo: path.join(__dirname, 'src/styleguidist/components/logo.js'),

--- a/test/unit/hoc/LazyLoad.spec.js
+++ b/test/unit/hoc/LazyLoad.spec.js
@@ -1,0 +1,35 @@
+import Vue from 'vue/dist/vue.common'
+import Lazy from '../../../src/components/shared/hoc/LazyLoad'
+
+window.IntersectionObserver = jest.fn(() => ({
+    observe: jest.fn(),
+}))
+
+const Constructor = Vue.extend(Lazy)
+const mounted = jest.fn()
+const renderer = Vue.compile('<div>Test</div>')
+const patsy = {
+    render: renderer.render,
+    staticRenderFns: renderer.staticRenderFns,
+    mounted,
+}
+
+const vm = new Constructor()
+
+vm.$slots.default = [vm.$createElement(patsy)]
+vm.$mount()
+
+describe('Lazy Load', () => {
+    it('should match the snapshot', () => {
+        expect(vm.$el).toMatchSnapshot()
+    })
+
+    it('should lazy load when in view', (done) => {
+        vm.outOfView = false
+        vm.$nextTick(() => {
+            expect(vm.$el).toMatchSnapshot()
+            expect(mounted).toHaveBeenCalled()
+            done()
+        })
+    })
+})

--- a/test/unit/hoc/__snapshots__/LazyLoad.spec.js.snap
+++ b/test/unit/hoc/__snapshots__/LazyLoad.spec.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Lazy Load should lazy load when in view 1`] = `
+<div>
+  <div>
+    Test
+  </div>
+</div>
+`;
+
+exports[`Lazy Load should match the snapshot 1`] = `
+<div
+  class="placeholder"
+>
+  
+</div>
+`;


### PR DESCRIPTION
A new Higher Order Component to lazy load/mount content only when in the view port.
This can be used to offset the loading of images that may never be seen or stop prematurely mounting a component with expensive lifecycle hooks.

See docs for usage