### PR TITLE
Panel tweak

### DIFF
--- a/src/components/shared/layout/Panel.vue
+++ b/src/components/shared/layout/Panel.vue
@@ -96,16 +96,11 @@
         background: $croud-colour-card;
     }
 
-    .ui.basic {
-        /*padding: 0 1em;*/
-    }
 </style>
 
 <style lang="scss">
 
     .ui.segment.filterbox.text.menu {
-        /*margin-left: -1em
-        margin-right: -1em*/
         border-bottom: 1px solid hsla(0,0%,39%,.07);
 
         + .loader-container {

--- a/src/components/shared/layout/Panel.vue
+++ b/src/components/shared/layout/Panel.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="ui segments">
-        <div class="ui basic segment text menu">
+        <div v-if="title || showCollapseToggle" class="ui basic segment text menu">
             <div class="item">
                 <h2 class="heading ui-sortable-handle">{{ title }}</h2>
             </div>

--- a/test/unit/layout/Panel.spec.js
+++ b/test/unit/layout/Panel.spec.js
@@ -3,10 +3,39 @@ import Panel from '../../../src/components/shared/layout/Panel'
 
 const Constructor = Vue.extend(Panel)
 
-const vm = new Constructor().$mount()
+// const vm = new Constructor().$mount()
+
+
+const vm = new Constructor({
+    propsData: {
+        title: 'Test Panel',
+        showCollapseToggle: true,
+    },
+}).$mount()
 
 describe('Panel', () => {
     it('should match the snapshot', () => {
         expect(vm.$el).toMatchSnapshot()
+    })
+})
+
+describe('showCollapseToggle is false', () => {
+    beforeEach(() => {
+        vm.showCollapseToggle = false
+    })
+
+    it('shouldnt show the show / collapse button', () => {
+        expect(vm.$el.querySelectorAll('.circular .angle .icon').length).toBe(0)
+    })
+})
+
+describe('No title length and showCollapseToggle is false', () => {
+    beforeEach(() => {
+        vm.title = ''
+        vm.showCollapseToggle = false
+    })
+
+    it('shouldnt show the text segment', () => {
+        expect(vm.$el.querySelectorAll('.text').length).toBe(0)
     })
 })

--- a/test/unit/layout/Panel.spec.js
+++ b/test/unit/layout/Panel.spec.js
@@ -36,6 +36,6 @@ describe('No title length and showCollapseToggle is false', () => {
     })
 
     it('shouldnt show the text segment', () => {
-        expect(vm.$el.querySelectorAll('.text').length).toBe(0)
+        expect(vm.$el.querySelectorAll('.text.menu').length).toBe(0)
     })
 })

--- a/test/unit/layout/Panel.spec.js
+++ b/test/unit/layout/Panel.spec.js
@@ -17,6 +17,14 @@ describe('Panel', () => {
     it('should match the snapshot', () => {
         expect(vm.$el).toMatchSnapshot()
     })
+
+    it('should show the show / collapse button', () => {
+        expect(vm.$el.querySelectorAll('.circular.angle.icon').length).toBe(1)
+    })
+
+    it('should show the text segment', () => {
+        expect(vm.$el.querySelectorAll('.text.menu').length).toBe(1)
+    })
 })
 
 describe('showCollapseToggle is false', () => {
@@ -25,7 +33,7 @@ describe('showCollapseToggle is false', () => {
     })
 
     it('shouldnt show the show / collapse button', () => {
-        expect(vm.$el.querySelectorAll('.circular .angle .icon').length).toBe(0)
+        expect(vm.$el.querySelectorAll('.circular.angle.icon').length).toBe(0)
     })
 })
 

--- a/test/unit/layout/__snapshots__/Panel.spec.js.snap
+++ b/test/unit/layout/__snapshots__/Panel.spec.js.snap
@@ -13,7 +13,7 @@ exports[`Panel should match the snapshot 1`] = `
       <h2
         class="heading ui-sortable-handle"
       >
-        Title
+        Test Panel
       </h2>
     </div>
     <div


### PR DESCRIPTION
This update allows us to hide the title segment if the title is blank and the toggle show/collapse button prop is false