### PR TITLE
Sheduler editor defaults

### DIFF
--- a/src/components/shared/mixins/schedule.js
+++ b/src/components/shared/mixins/schedule.js
@@ -50,7 +50,7 @@ export default {
                 },
                 limit: {
                     startsAt: moment().format('YYYY-MM-DD hh:mm:ss'),
-                    endsAt: '',
+                    endsAt: null,
                     maxExecutions: null,
                 },
             },

--- a/src/components/shared/mixins/schedule.js
+++ b/src/components/shared/mixins/schedule.js
@@ -1,4 +1,4 @@
-import { cloneDeep, defaultsDeep } from 'lodash'
+import { cloneDeep, defaultsDeep, defaults } from 'lodash'
 import moment from 'moment-timezone'
 
 export default {
@@ -70,12 +70,11 @@ export default {
             moment.weekdays().forEach((key) => { days[key.toLowerCase()] = false })
             if (frequency && frequency.days) frequency.days.forEach((key) => { days[key] = true })
 
-            const freq = {
-                ...frequency,
+            const freq = defaults({
                 days,
                 months,
                 at: frequency.at ? frequency.at[0] : undefined,
-            }
+            }, frequency)
 
             const limit = {
                 startsAt: root[this.keys.startsAt] || undefined,

--- a/src/components/shared/mixins/schedule.js
+++ b/src/components/shared/mixins/schedule.js
@@ -71,25 +71,21 @@ export default {
             if (frequency && frequency.days) frequency.days.forEach((key) => { days[key] = true })
 
             const freq = {
+                ...frequency,
                 days,
                 months,
-                at: frequency.at ? frequency.at[0] : '00:00',
-                recur: frequency.recur || 'daily',
-                timezone: frequency.timezone || 'Europe/London',
+                at: frequency.at ? frequency.at[0] : undefined,
             }
 
-            const startsAt = root[this.keys.startsAt]
-            const endsAt = root[this.keys.endsAt]
-
-            const limit = {}
-            limit.startsAt = startsAt ? moment(startsAt, 'YYYY-MM-DD hh:mm:ss').format('YYYY-MM-DD hh:mm:ss') : ''
-            limit.endsAt = endsAt ? moment(endsAt, 'YYYY-MM-DD hh:mm:ss').format('YYYY-MM-DD hh:mm:ss') : ''
-            limit.maxExecutions = root[this.keys.maxExecutions] || null
+            const limit = {
+                startsAt: root[this.keys.startsAt] || undefined,
+                endsAt: root[this.keys.endsAt] || undefined,
+                maxExecutions: root[this.keys.maxExecutions] || undefined,
+            }
 
             const build = {
                 frequency: freq,
                 limit,
-                timezone: frequency.timezone || 'Europe/London',
             }
 
             this.schedule = defaultsDeep(build, this.schedule)

--- a/src/components/shared/scheduler/SchedulerEditor.vue
+++ b/src/components/shared/scheduler/SchedulerEditor.vue
@@ -128,7 +128,8 @@
 
         data() {
             return {
-                alternating_start: 0,
+                alternatingStart: 0,
+                dateFormat: 'YYYY-MM-DD hh:mm:ss',
             }
         },
 
@@ -198,11 +199,11 @@
 
         methods: {
             setStartDate(option) {
-                this.schedule.limit.startsAt = option.format('YYYY-MM-DD hh:mm:ss')
+                this.schedule.limit.startsAt = option.format(this.dateFormat)
             },
 
             setEndDate(option) {
-                this.schedule.limit.endsAt = option.format('YYYY-MM-DD hh:mm:ss')
+                this.schedule.limit.endsAt = option.format(this.dateFormat)
             },
 
             setAllMonths(option = true) {
@@ -217,8 +218,8 @@
             },
 
             setAlternateMonths() {
-                this.alternating_start = this.alternating_start === 1 ? 0 : 1
-                const index = this.alternating_start % 2 ? 1 : 0
+                this.alternatingStart = this.alternatingStart === 1 ? 0 : 1
+                const index = this.alternatingStart % 2 ? 1 : 0
 
                 moment.months().forEach((month, i) => {
                     this.schedule.frequency.months[moment().month(i).format('MMMM').toLowerCase()] = i % 2 === index

--- a/src/components/shared/scheduler/SchedulerEditor.vue
+++ b/src/components/shared/scheduler/SchedulerEditor.vue
@@ -129,7 +129,7 @@
         data() {
             return {
                 alternatingStart: 0,
-                dateFormat: 'YYYY-MM-DD hh:mm:ss',
+                dateFormat: 'YYYY-MM-DD HH:mm:ss',
             }
         },
 

--- a/src/components/shared/scheduler/SchedulerEditor.vue
+++ b/src/components/shared/scheduler/SchedulerEditor.vue
@@ -67,7 +67,7 @@
                         <label>Time this schedule runs at</label>
                         <semantic-form-dropdown v-model="schedule.frequency.at" :options="timeOptions"></semantic-form-dropdown>
                         <div class="ui light" style="margin-top:5px">
-                            (Timezone: <strong>{{ schedule.timezone }}</strong>)
+                            (Timezone: <strong>{{ schedule.frequency.timezone }}</strong>)
                         </div>
                     </div>
 

--- a/src/components/shared/scheduler/SchedulerEditor.vue
+++ b/src/components/shared/scheduler/SchedulerEditor.vue
@@ -139,24 +139,19 @@
                 const days = Object.keys(schedule.frequency.days).filter(day => schedule.frequency.days[day])
                 const months = Object.keys(schedule.frequency.months).filter(month => schedule.frequency.months[month])
 
-                const frequency = {
-                    recur: schedule.frequency.recur,
-                    at: schedule.frequency.at = [schedule.frequency.at],
-                    timezone: schedule.frequency.timezone,
+                return {
+                    ...this.rootObject,
+                    [this.keys.frequency]: {
+                        recur: schedule.frequency.recur,
+                        at: schedule.frequency.at ? [schedule.frequency.at] : null,
+                        timezone: schedule.frequency.timezone,
+                        days: days.length ? days : null,
+                        months: months.length ? months : null,
+                    },
+                    [this.keys.startsAt]: schedule.limit.startsAt ? moment(schedule.limit.startsAt).format(this.dateFormat) : null,
+                    [this.keys.endsAt]: schedule.limit.endsAt ? moment(schedule.limit.endsAt).format(this.dateFormat) : null,
+                    [this.keys.maxExecutions]: schedule.limit.maxExecutions > 0 ? parseInt(schedule.limit.maxExecutions, 10) : null,
                 }
-
-                frequency.months = months.length ? months : null
-                frequency.days = days.length ? days : null
-
-                const schedulerObject = {
-                    [this.keys.frequency]: frequency,
-                }
-
-                schedulerObject[this.keys.startsAt] = schedule.limit.startsAt ? moment(schedule.limit.startsAt).format('YYYY-MM-DD hh:mm:ss') : null
-                schedulerObject[this.keys.endsAt] = schedule.limit.endsAt ? moment(schedule.limit.endsAt).format('YYYY-MM-DD hh:mm:ss') : null
-                schedulerObject[this.keys.maxExecutions] = schedule.limit.maxExecutions > 0 ? parseInt(schedule.limit.maxExecutions, 10) : null
-
-                return { ...this.rootObject, ...schedulerObject }
             },
 
             periodOptions() {

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -73,6 +73,10 @@ module.exports = {
             ],
         },
         {
+            name: 'Scheduler',
+            components: 'src/components/shared/scheduler/**/*.vue',
+        },
+        {
             name: 'Misc',
             components: 'src/components/shared/misc/**/*.vue',
             sections: [

--- a/test/unit/schedule/SchedulerEditor.spec.js
+++ b/test/unit/schedule/SchedulerEditor.spec.js
@@ -150,22 +150,22 @@ describe('Scheduler Editor', () => {
             describe('limits', () => {
                 it('should set the start date', (done) => {
                     vm.rootObject = {
-                        [keys.startsAt]: '2018-03-07 12:00:00',
+                        [keys.startsAt]: '2018-03-07 00:00:00',
                     }
 
                     vm.$nextTick(() => {
-                        expect(vm.schedule.limit.startsAt).toBe('2018-03-07 12:00:00')
+                        expect(vm.schedule.limit.startsAt).toBe('2018-03-07 00:00:00')
                         done()
                     })
                 })
 
                 it('should set the end date', (done) => {
                     vm.rootObject = {
-                        [keys.endsAt]: '2018-03-07 12:00:00',
+                        [keys.endsAt]: '2018-03-07 00:00:00',
                     }
 
                     vm.$nextTick(() => {
-                        expect(vm.schedule.limit.endsAt).toBe('2018-03-07 12:00:00')
+                        expect(vm.schedule.limit.endsAt).toBe('2018-03-07 00:00:00')
                         done()
                     })
                 })
@@ -183,8 +183,8 @@ describe('Scheduler Editor', () => {
 
                 it('should match snapshot', (done) => {
                     vm.rootObject = {
-                        [keys.startsAt]: '2018-03-07 12:00:00',
-                        [keys.endsAt]: '2018-04-07 12:00:00',
+                        [keys.startsAt]: '2018-03-07 00:00:00',
+                        [keys.endsAt]: '2018-04-07 00:00:00',
                         [keys.maxExecutions]: 10,
                     }
 
@@ -204,8 +204,8 @@ describe('Scheduler Editor', () => {
                         timezone: 'Europe/Berlin',
                         recur: 'thirdWeekOfMonth',
                     },
-                    [keys.startsAt]: '2018-03-07 12:00:00',
-                    [keys.endsAt]: '2018-04-07 12:00:00',
+                    [keys.startsAt]: '2018-03-07 00:00:00',
+                    [keys.endsAt]: '2018-04-07 00:00:00',
                     [keys.maxExecutions]: 10,
                 }
 
@@ -311,19 +311,19 @@ describe('Scheduler Editor', () => {
 
             describe('limits', () => {
                 it('should set the start date', (done) => {
-                    vm.schedule.limit.startsAt = '2018-04-07 12:00:00'
+                    vm.schedule.limit.startsAt = '2018-04-07 00:00:00'
 
                     vm.$nextTick(() => {
-                        expect(vm.getSchedulerObject[keys.startsAt]).toBe('2018-04-07 12:00:00')
+                        expect(vm.getSchedulerObject[keys.startsAt]).toBe('2018-04-07 00:00:00')
                         done()
                     })
                 })
 
                 it('should set the end date', (done) => {
-                    vm.schedule.limit.endsAt = '2018-04-07 12:00:00'
+                    vm.schedule.limit.endsAt = '2018-04-07 00:00:00'
 
                     vm.$nextTick(() => {
-                        expect(vm.getSchedulerObject[keys.endsAt]).toBe('2018-04-07 12:00:00')
+                        expect(vm.getSchedulerObject[keys.endsAt]).toBe('2018-04-07 00:00:00')
                         done()
                     })
                 })
@@ -338,8 +338,8 @@ describe('Scheduler Editor', () => {
                 })
 
                 it('should match snapshot', (done) => {
-                    vm.schedule.limit.startsAt = '2018-04-07 12:00:00'
-                    vm.schedule.limit.endsAt = '2018-04-06 12:00:00'
+                    vm.schedule.limit.startsAt = '2018-04-07 00:00:00'
+                    vm.schedule.limit.endsAt = '2018-04-06 00:00:00'
                     vm.schedule.limit.maxExecutions = 2
 
                     vm.$nextTick(() => {
@@ -379,8 +379,8 @@ describe('Scheduler Editor', () => {
                     },
                 }
 
-                vm.schedule.limit.startsAt = '2018-04-02 12:00:00'
-                vm.schedule.limit.endsAt = '2018-04-03 12:00:00'
+                vm.schedule.limit.startsAt = '2018-04-02 00:00:00'
+                vm.schedule.limit.endsAt = '2018-04-03 00:00:00'
                 vm.schedule.limit.maxExecutions = 7
 
                 vm.$nextTick(() => {

--- a/test/unit/schedule/SchedulerEditor.spec.js
+++ b/test/unit/schedule/SchedulerEditor.spec.js
@@ -1,9 +1,12 @@
 import Vue from 'vue'
 import { pick } from 'lodash'
 import VueSemantic from 'croud-vue-semantic'
+import moment from 'moment-timezone'
 
 import SchedulerEditor from '../../../src/components/shared/scheduler/SchedulerEditor'
 import '../../../semantic/dist/semantic'
+
+moment.tz.guess = jest.fn(() => 'Europe/London')
 
 Vue.use(VueSemantic)
 

--- a/test/unit/schedule/SchedulerEditor.spec.js
+++ b/test/unit/schedule/SchedulerEditor.spec.js
@@ -6,7 +6,7 @@ import moment from 'moment-timezone'
 import SchedulerEditor from '../../../src/components/shared/scheduler/SchedulerEditor'
 import '../../../semantic/dist/semantic'
 
-moment.tz.guess = jest.fn(() => 'Europe/London')
+moment.tz.guess = jest.fn(() => 'Etc/UTC')
 
 Vue.use(VueSemantic)
 

--- a/test/unit/schedule/SchedulerEditor.spec.js
+++ b/test/unit/schedule/SchedulerEditor.spec.js
@@ -7,6 +7,7 @@ import SchedulerEditor from '../../../src/components/shared/scheduler/SchedulerE
 import '../../../semantic/dist/semantic'
 
 moment.tz.guess = jest.fn(() => 'Etc/UTC')
+Date.now = jest.fn(() => 1520640000000)
 
 Vue.use(VueSemantic)
 

--- a/test/unit/schedule/SchedulerModal.spec.js
+++ b/test/unit/schedule/SchedulerModal.spec.js
@@ -1,8 +1,11 @@
 import Vue from 'vue'
 import VueSemantic from 'croud-vue-semantic'
+import moment from 'moment-timezone'
 
 import '../../../semantic/dist/semantic'
 import SchedulerModal from '../../../src/components/shared/scheduler/SchedulerModal'
+
+moment.tz.guess = jest.fn(() => 'Etc/UTC')
 
 Vue.use(VueSemantic)
 

--- a/test/unit/schedule/SchedulerText.spec.js
+++ b/test/unit/schedule/SchedulerText.spec.js
@@ -105,21 +105,10 @@ describe('Scheduler Text', () => {
         })
 
         describe('limits', () => {
-            it('should handle no date limits', (done) => {
-                vm.rootObject = {
-                    [keys.startsAt]: null,
-                    [keys.endsAt]: null,
-                }
-                vm.$nextTick(() => {
-                    expect(vm.datesText).toBe('')
-                    done()
-                })
-            })
-
             it('should handle an upcoming date range', (done) => {
                 vm.rootObject = {
-                    [keys.startsAt]: moment().add(1, 'day').format('YYYY-MM-DD hh:mm:ss'),
-                    [keys.endsAt]: moment().add(2, 'day').format('YYYY-MM-DD hh:mm:ss'),
+                    [keys.startsAt]: moment().add(1, 'day').format('YYYY-MM-DD HH:mm:ss'),
+                    [keys.endsAt]: moment().add(2, 'day').format('YYYY-MM-DD HH:mm:ss'),
                 }
                 vm.$nextTick(() => {
                     expect(vm.datesText).toContain('between')
@@ -130,7 +119,8 @@ describe('Scheduler Text', () => {
             describe('end date', () => {
                 it('should handle end date', (done) => {
                     vm.rootObject = {
-                        [keys.endsAt]: moment().add(1, 'day').format('YYYY-MM-DD hh:mm:ss'),
+                        [keys.startsAt]: moment().subtract(1, 'day').format('YYYY-MM-DD HH:mm:ss'),
+                        [keys.endsAt]: moment().add(1, 'day').format('YYYY-MM-DD HH:mm:ss'),
                     }
                     vm.$nextTick(() => {
                         expect(vm.datesText).toContain('ending')
@@ -141,7 +131,8 @@ describe('Scheduler Text', () => {
 
                 it('should handle passed end date', (done) => {
                     vm.rootObject = {
-                        [keys.endsAt]: moment().subtract(1, 'day').format('YYYY-MM-DD hh:mm:ss'),
+                        [keys.startsAt]: moment().subtract(2, 'day').format('YYYY-MM-DD HH:mm:ss'),
+                        [keys.endsAt]: moment().subtract(1, 'day').format('YYYY-MM-DD HH:mm:ss'),
                     }
                     vm.$nextTick(() => {
                         expect(vm.datesText).toContain('ended')

--- a/test/unit/schedule/__snapshots__/SchedulerEditor.spec.js.snap
+++ b/test/unit/schedule/__snapshots__/SchedulerEditor.spec.js.snap
@@ -33,9 +33,9 @@ Object {
 
 exports[`Scheduler Editor data transformation input limits should match snapshot 1`] = `
 Object {
-  "endsAt": "2018-04-07 12:00:00",
+  "endsAt": "2018-04-07 00:00:00",
   "maxExecutions": 10,
-  "startsAt": "2018-03-07 12:00:00",
+  "startsAt": "2018-03-07 00:00:00",
 }
 `;
 
@@ -70,9 +70,9 @@ Object {
     "timezone": "Europe/Berlin",
   },
   "limit": Object {
-    "endsAt": "2018-04-07 12:00:00",
+    "endsAt": "2018-04-07 00:00:00",
     "maxExecutions": 10,
-    "startsAt": "2018-03-07 12:00:00",
+    "startsAt": "2018-03-07 00:00:00",
   },
 }
 `;
@@ -97,15 +97,15 @@ Object {
 
 exports[`Scheduler Editor data transformation output limits should match snapshot 1`] = `
 Object {
-  "service=scheduler;table=timetables;field=ends_at;": "2018-04-06 12:00:00",
+  "service=scheduler;table=timetables;field=ends_at;": "2018-04-06 00:00:00",
   "service=scheduler;table=timetables;field=max_executions;": 2,
-  "service=scheduler;table=timetables;field=starts_at;": "2018-04-07 12:00:00",
+  "service=scheduler;table=timetables;field=starts_at;": "2018-04-07 00:00:00",
 }
 `;
 
 exports[`Scheduler Editor data transformation output should match snapshot 1`] = `
 Object {
-  "service=scheduler;table=timetables;field=ends_at;": "2018-04-03 12:00:00",
+  "service=scheduler;table=timetables;field=ends_at;": "2018-04-03 00:00:00",
   "service=scheduler;table=timetables;field=frequency;": Object {
     "at": Array [
       "22:55",
@@ -124,7 +124,7 @@ Object {
     "timezone": "Europe/Madrid",
   },
   "service=scheduler;table=timetables;field=max_executions;": 7,
-  "service=scheduler;table=timetables;field=starts_at;": "2018-04-02 12:00:00",
+  "service=scheduler;table=timetables;field=starts_at;": "2018-04-02 00:00:00",
 }
 `;
 
@@ -2753,7 +2753,7 @@ Object {
   "limit": Object {
     "endsAt": "",
     "maxExecutions": null,
-    "startsAt": "2018-03-10 12:00:00",
+    "startsAt": "2018-03-10 00:00:00",
   },
 }
 `;

--- a/test/unit/schedule/__snapshots__/SchedulerEditor.spec.js.snap
+++ b/test/unit/schedule/__snapshots__/SchedulerEditor.spec.js.snap
@@ -2687,7 +2687,7 @@ exports[`Scheduler Editor empty schedule should match the snapshot 1`] = `
           >
             (Timezone: 
             <strong>
-              Europe/London
+              Etc/UTC
             </strong>
             )
           </div>
@@ -2748,7 +2748,7 @@ Object {
       "september": false,
     },
     "recur": "daily",
-    "timezone": "Europe/London",
+    "timezone": "Etc/UTC",
   },
   "limit": Object {
     "endsAt": "",

--- a/test/unit/schedule/__snapshots__/SchedulerEditor.spec.js.snap
+++ b/test/unit/schedule/__snapshots__/SchedulerEditor.spec.js.snap
@@ -74,7 +74,6 @@ Object {
     "maxExecutions": 10,
     "startsAt": "2018-03-07 12:00:00",
   },
-  "timezone": "Europe/Berlin",
 }
 `;
 
@@ -2754,8 +2753,7 @@ Object {
   "limit": Object {
     "endsAt": "",
     "maxExecutions": null,
-    "startsAt": "",
+    "startsAt": "2018-03-10 12:00:00",
   },
-  "timezone": "Europe/London",
 }
 `;

--- a/test/unit/schedule/__snapshots__/SchedulerEditor.spec.js.snap
+++ b/test/unit/schedule/__snapshots__/SchedulerEditor.spec.js.snap
@@ -2751,7 +2751,7 @@ Object {
     "timezone": "Etc/UTC",
   },
   "limit": Object {
-    "endsAt": "",
+    "endsAt": null,
     "maxExecutions": null,
     "startsAt": "2018-03-10 00:00:00",
   },

--- a/test/unit/schedule/__snapshots__/SchedulerModal.spec.js.snap
+++ b/test/unit/schedule/__snapshots__/SchedulerModal.spec.js.snap
@@ -2602,7 +2602,7 @@ exports[`Scheduler Modal open modal should show scheduler 1`] = `
                 >
                   (Timezone: 
                   <strong>
-                    Europe/London
+                    Etc/UTC
                   </strong>
                   )
                 </div>


### PR DESCRIPTION
This breaks the current test coverage of #51 so needs careful consideration again.

- I have refactored the inbound data transformer to fall back to using the scheduler's defaults (This has broken the no schedule set snapshot)
- Removed duplicate timezone key (broke snapshots)
- Tidied up some variables on the scheduler editor.
- Refactored outgoing data transformer to make it easier to reason about what is happening.
- Moved datetime stamp to use 24 hour time as it is less ambiguous. (broke tests and snapshots)