### PR TITLE
Multi selector refactor

### DIFF
--- a/src/components/shared/misc/SummarisedMultiSelector.vue
+++ b/src/components/shared/misc/SummarisedMultiSelector.vue
@@ -11,8 +11,8 @@
             :auto-update="false"
             :autoUpdateOptions="false"
             :full_text_search="true"
-            :title_field="fields.title"
-            :value_field="fields.value"
+            :title_field="computedFields.title"
+            :value_field="computedFields.value"
             :inline="inline"
             :fluid="fluid"
             search multiple
@@ -53,14 +53,12 @@
             },
 
             /**
-            * Maps the dropdown to the title/value fields on your options array.
+            * Maps the dropdown to the title/value/summary fields on your options array. By default, value will use the 'id' field and title and summary will use the 'name' field
             */
             fields: {
                 type: Object,
                 default() {
                     return {
-                        title: 'name',
-                        value: 'id',
                     }
                 },
             },
@@ -96,15 +94,6 @@
                 },
             },
 
-            /**
-            * Which field in the options to use in the summary popup
-            */
-            summaryField: {
-                type: String,
-                default() {
-                    return 'name'
-                },
-            },
 
             /**
             * Semantic ui dropdown configuration
@@ -162,6 +151,15 @@
                 },
             },
 
+            computedFields() {
+                return {
+                    value: 'id',
+                    title: 'name',
+                    summary: 'name',
+                    ...this.fields,
+                }
+            },
+
             computedModel() {
                 return Array.isArray(this.model) ? this.model : this.model.split(',')
             },
@@ -171,11 +169,13 @@
             },
 
             selectedItems() {
+                const normalised = this.computedModel.map(v => v.toString())
+
                 return this.options.filter((option) => {
-                    if (this.computedModel.toString().indexOf(option[this.fields.value].toString()) > -1) {
-                        return option[this.fields.value]
+                    if (normalised.indexOf(option[this.computedFields.value].toString()) > -1) {
+                        return option[this.computedFields.value]
                     } return null
-                }).map(selected => selected[this.summaryField]).join(', ')
+                }).map(selected => selected[this.computedFields.summary]).join(', ')
             },
 
             summary() {

--- a/src/components/shared/misc/SummarisedMultiSelector.vue
+++ b/src/components/shared/misc/SummarisedMultiSelector.vue
@@ -20,7 +20,7 @@
             @dropdown-selected="dropdownSelected"
         />
 
-        <div v-if="readOnly && selectedLength < 1" :data-inverted="true">
+        <div v-if="readOnly && selectedLength < 1">
             {{ placeholder }}
         </div>
 
@@ -175,6 +175,7 @@
             },
 
             selectedItems() {
+                console.log(this.computedModel.toString())
                 return this.options.filter((option) => {
                     if (this.computedModel.toString().indexOf(option[this.fields.value].toString()) > -1) {
                         return option[this.fields.value]

--- a/src/components/shared/misc/SummarisedMultiSelector.vue
+++ b/src/components/shared/misc/SummarisedMultiSelector.vue
@@ -24,12 +24,8 @@
             {{ placeholder }}
         </div>
 
-        <div v-else-if="readOnly && selectedLength < 2" :data-tooltip="selectedItems" :data-inverted="true">
-            {{ selectedItems }}
-        </div>
-
-        <div v-else-if="readOnly && selectedLength > 1" :data-tooltip="selectedItems" :data-inverted="true">
-             {{ selectedLength }} Selected
+        <div v-else-if="readOnly && selectedLength" :data-tooltip="selectedItems" :data-inverted="true">
+            {{ displayText }}
         </div>
     </div>
 </template>
@@ -175,7 +171,6 @@
             },
 
             selectedItems() {
-                console.log(this.computedModel.toString())
                 return this.options.filter((option) => {
                     if (this.computedModel.toString().indexOf(option[this.fields.value].toString()) > -1) {
                         return option[this.fields.value]
@@ -187,6 +182,13 @@
                 if (this.model.length < 1) return this.defaultSummary
                 return this.selectedItems
             },
+
+            displayText() {
+                if (this.selectedLength < 2) {
+                    return this.selectedItems
+                }
+                return `${this.selectedLength} Selected`
+            },
         },
 
         methods: {
@@ -196,11 +198,7 @@
 
             setLabel() {
                 if (this.model.length < 1) return
-                if (this.selectedLength < 2) {
-                    $(this.$refs.summarisedSelector.$el).dropdown('set text', this.selectedItems)
-                } else {
-                    $(this.$refs.summarisedSelector.$el).dropdown('set text', `${this.selectedLength} Selected`)
-                }
+                $(this.$refs.summarisedSelector.$el).dropdown('set text', this.displayText)
             },
 
             reset() {


### PR DESCRIPTION
Slight refactor and bug fix for the multiple selector refactor.

- There was a lot of duplicated logic based on the amount of items selected, this has been moved to a single computed value that will be cached and used all over this component.
- This change allows for the summary field to be passed in with the other field props and uses a computed value to set the defaults so the user can pass in a subset of the prop object without losing the other defaults.
- This also fixes the substring issue on the summary builder.

These changes haven't broken any of our current tests and appears to work with the examples on the styleguide. I will create another PR to increase the test coverage once this gets merged in.

refs #46 