### PR TITLE
Force summarised dropdown to open downwards

### DIFF
--- a/src/components/shared/misc/SummarisedMultiSelector.vue
+++ b/src/components/shared/misc/SummarisedMultiSelector.vue
@@ -104,6 +104,7 @@
                     return {
                         useLabels: false,
                         showOnFocus: true,
+                        direction: 'downward',
                         onHide: () => this.$emit('dropdown-hidden'),
                     }
                 },


### PR DESCRIPTION
This PR fixes an issue where the dropdown can sometimes open upwards and clash with the summarised popup, this change will ensure the dropdown always opens in a downward direction