### PR TITLE
summarised dropdown: hide popup when dropdown menu is shown

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "croud-style-guide",
-  "version": "1.7.3",
+  "version": "1.8.0",
   "description": "A Vue.js project",
   "author": "antony.king@croud.co.uk",
   "private": false,

--- a/src/components/shared/misc/SummarisedMultiSelector.vue
+++ b/src/components/shared/misc/SummarisedMultiSelector.vue
@@ -5,7 +5,7 @@
             v-show="!readOnly"
             v-model="model"
             :options="options"
-            :data-tooltip="summary"
+            :data-tooltip="dropdownSummary"
             :placeholder="placeholder"
             :data-inverted="true"
             :auto-update="false"
@@ -40,6 +40,12 @@
     export default {
 
         name: 'croud-summarised-multi-selector',
+
+        data() {
+            return {
+                showSummary: true,
+            }
+        },
 
         props: {
             /**
@@ -104,7 +110,13 @@
                     return {
                         useLabels: false,
                         showOnFocus: true,
-                        onHide: () => this.$emit('dropdown-hidden'),
+                        onShow: () => {
+                            this.showSummary = false
+                        },
+                        onHide: () => {
+                            this.showSummary = true
+                            this.$emit('dropdown-hidden')
+                        },
                     }
                 },
             },
@@ -181,6 +193,10 @@
             summary() {
                 if (this.model.length < 1) return this.defaultSummary
                 return this.selectedItems
+            },
+
+            dropdownSummary() {
+                return this.showSummary ? this.summary : this.showSummary
             },
 
             displayText() {

--- a/test/unit/misc/__snapshots__/SummarisedMultiSelector.spec.js.snap
+++ b/test/unit/misc/__snapshots__/SummarisedMultiSelector.spec.js.snap
@@ -25,7 +25,7 @@ exports[`summarised multi selector none selected read only should match the snap
     <div
       class="default text"
     >
-
+      
     </div>
     <i
       class="dropdown icon"
@@ -61,7 +61,7 @@ exports[`summarised multi selector none selected read only should match the snap
     data-tooltip=""
     data-inverted="true"
   >
-
+    
   </div>
 </div>
 `;
@@ -90,7 +90,7 @@ exports[`summarised multi selector none selected should match the snapshot 1`] =
     <div
       class="default text"
     >
-
+      
     </div>
     <i
       class="dropdown icon"
@@ -263,7 +263,7 @@ exports[`summarised multi selector some selected build summary if dropdown is op
   class="dropdown-wrapper"
 >
   <div
-    class="ui dropdown search fluid multiple inline"
+    class="ui selection dropdown search multiple"
     data-inverted="true"
     style="display: none;"
   >
@@ -328,7 +328,7 @@ exports[`summarised multi selector some selected read only should match the snap
   class="dropdown-wrapper"
 >
   <div
-    class="ui dropdown search fluid multiple inline"
+    class="ui selection dropdown search multiple"
     data-inverted="true"
     style="display: none;"
     data-tooltip="PPC, Paid Social"


### PR DESCRIPTION
This change ensures the summary popup is hidden when the dropdown menu is visible. Change is approved by product. (Fixes #60)